### PR TITLE
Add CustomHeader widget and refactor pages

### DIFF
--- a/lib/DFA/pages/dfa_page.dart
+++ b/lib/DFA/pages/dfa_page.dart
@@ -11,7 +11,7 @@ import 'package:automaton_simulator/DFA/simulator/simulation_control_panel.dart'
 import 'package:automaton_simulator/DFA/simulator/simulator_class.dart';
 import 'package:provider/provider.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:automaton_simulator/common/widgets/custom_header.dart';
 
 class DfaPage extends StatefulWidget {
   const DfaPage({super.key});
@@ -50,7 +50,7 @@ class DfaPageState extends State<DfaPage> {
         child: SafeArea(
           child: Column(
             children: [
-              buildCustomHeader(),
+              CustomHeader(title: "DFA Simulator", onBack: () { automaton.reset(); Navigator.of(context).pop(); }, onHelp: () { showTutorial(); },),
               Expanded(
                 child: LayoutBuilder(
                   builder: (context, constraints) {
@@ -72,54 +72,6 @@ class DfaPageState extends State<DfaPage> {
     );
   }
 
-  Widget buildCustomHeader() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [Colors.deepPurple.shade800, Colors.deepPurple.shade500],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: const BorderRadius.only(
-          bottomLeft: Radius.circular(20),
-          bottomRight: Radius.circular(20),
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          IconButton(
-            icon: const Icon(FontAwesomeIcons.arrowLeft,
-                color: Colors.white, size: 22),
-            onPressed: () {
-              automaton.reset();
-              Navigator.of(context).pop();
-            },
-          ),
-          const Text(
-            'DFA Simulator',
-            style: TextStyle(
-              fontFamily: 'Poppins',
-              fontSize: 35,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(0, 0, 12, 0),
-            child: IconButton(
-              icon: const Icon(FontAwesomeIcons.circleQuestion,
-                  color: Colors.white, size: 22),
-              onPressed: () {
-                showTutorial();
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 
   Widget buildEditorPanel() {
     return Expanded(

--- a/lib/PDA/pda_page.dart
+++ b/lib/PDA/pda_page.dart
@@ -10,6 +10,7 @@ import 'package:automaton_simulator/PDA/editor_widget.dart';
 import 'package:automaton_simulator/classes/pda_class.dart';
 import 'package:provider/provider.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
+import 'package:automaton_simulator/common/widgets/custom_header.dart';
 
 class PdaPage extends StatefulWidget {
   const PdaPage({super.key});
@@ -49,7 +50,7 @@ class PdaPageState extends State<PdaPage> {
         child: SafeArea(
           child: Column(
             children: [
-              buildCustomHeader(),
+              CustomHeader(title: "PDA Simulator", onBack: () { automaton.reset(); Navigator.of(context).pop(); }, onHelp: () { showTutorial(); },),
               Expanded(
                 child: LayoutBuilder(
                   builder: (context, constraints) {
@@ -71,48 +72,6 @@ class PdaPageState extends State<PdaPage> {
     );
   }
 
-  Widget buildCustomHeader() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [Colors.deepPurple.shade800, Colors.deepPurple.shade500],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: const BorderRadius.only(
-          bottomLeft: Radius.circular(20),
-          bottomRight: Radius.circular(20),
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
-            onPressed: () {
-              automaton.reset();
-              Navigator.of(context).pop();
-            },
-          ),
-          Text(
-            'PDA Simulator',
-            style: GoogleFonts.rajdhani(
-              fontSize: 40,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.info_outline, color: Colors.white),
-            onPressed: () {
-              showTutorial(); // הצגת הדרכה בלחיצה על האייקון
-            },
-          ),
-        ],
-      ),
-    );
-  }
 
   Widget buildEditorPanel() {
     return Expanded(

--- a/lib/TM/tm_page.dart
+++ b/lib/TM/tm_page.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import 'package:automaton_simulator/common/widgets/custom_header.dart';
 class TmPage extends StatefulWidget {
   const TmPage({super.key});
 
@@ -166,7 +167,7 @@ class TmPageState extends State<TmPage> {
         child: SafeArea(
           child: Column(
             children: [
-              buildCustomHeader(),
+              CustomHeader(title: "Turing Machine Simulator", onBack: () { Navigator.of(context).pop(); }, onHelp: () { showTutorial(); },),
               Expanded(
                 child: SingleChildScrollView(
                   child: Padding(
@@ -196,47 +197,6 @@ class TmPageState extends State<TmPage> {
     );
   }
 
-  Widget buildCustomHeader() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [Colors.deepPurple.shade800, Colors.deepPurple.shade500],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: const BorderRadius.only(
-          bottomLeft: Radius.circular(20),
-          bottomRight: Radius.circular(20),
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-          ),
-          Text(
-            'Turing Machine Simulator',
-            style: GoogleFonts.rajdhani(
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          IconButton(
-            icon: const Icon(Icons.help_outline, color: Colors.white),
-            onPressed: () {
-              showTutorial();
-            },
-          ),
-        ],
-      ),
-    );
-  }
 
   Widget buildEditorArea() {
     return Container(

--- a/lib/common/widgets/custom_header.dart
+++ b/lib/common/widgets/custom_header.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class CustomHeader extends StatelessWidget {
+  final String title;
+  final VoidCallback onBack;
+  final VoidCallback onHelp;
+
+  const CustomHeader({
+    super.key,
+    required this.title,
+    required this.onBack,
+    required this.onHelp,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.deepPurple.shade800, Colors.deepPurple.shade500],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: const BorderRadius.only(
+          bottomLeft: Radius.circular(20),
+          bottomRight: Radius.circular(20),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IconButton(
+            icon: const Icon(FontAwesomeIcons.arrowLeft,
+                color: Colors.white, size: 22),
+            onPressed: onBack,
+          ),
+          Text(
+            title,
+            style: const TextStyle(
+              fontFamily: 'Poppins',
+              fontSize: 35,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 0, 12, 0),
+            child: IconButton(
+              icon: const Icon(FontAwesomeIcons.circleQuestion,
+                  color: Colors.white, size: 22),
+              onPressed: onHelp,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `CustomHeader` widget
- update automaton pages to use the new widget
- remove page-specific header methods

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdd7d08883258249f2c53b81e778